### PR TITLE
Run this test suite against both v12 and v14 of node.js

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -29,13 +29,17 @@ jobs:
         ports:
           - 6379/tcp
         options: --entrypoint redis-server
+    
+    strategy:
+      matrix:
+        node: [12, 14]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14
+      - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: ${{ matrix.node }}
       - run: npm ci
       - run: npm test
         env:


### PR DESCRIPTION
Ensure that customer Grouparoo applications work for both Node.js version 12.x.x and 14.x.x