### PR TITLE
Kube pods should be allowed to terminate gracefully

### DIFF
--- a/kube/grouparoo-web.yml
+++ b/kube/grouparoo-web.yml
@@ -12,6 +12,7 @@ spec:
       labels:
         app: grouparoo-web
     spec:
+      terminationGracePeriodSeconds: 30
       containers:
         - name: grouparoo-web
           image: grouparoo/app-example:latest

--- a/kube/grouparoo-worker.yml
+++ b/kube/grouparoo-worker.yml
@@ -12,6 +12,7 @@ spec:
       labels:
         app: grouparoo-worker
     spec:
+      terminationGracePeriodSeconds: 30
       containers:
         - name: grouparoo-worker
           image: grouparoo/app-example:latest


### PR DESCRIPTION
Use the directive `terminationGracePeriodSeconds` to allow some time for the Grouparoo workers to shut down gracefully in a Kubernetes deployment