### PR TITLE
Tag updates with core's version

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,6 +17,8 @@ jobs:
       - run: sudo npm install -g npm-check-updates
       - run: npm-check-updates -u
       - run: npm install
+      - name: store-core-version
+        run: echo CORE_VERSION=`cat package.json | jq '.dependencies."@grouparoo/core"'` >> $GITHUB_ENV
       - uses: stefanzweifel/git-auto-commit-action@v4.1.2
         with:
           commit_message: Updating Packages
@@ -24,3 +26,4 @@ jobs:
           commit_user_email: hello@grouparoo.com
           commit_author: Grouparoo Bot <hello@grouparoo.com>
           branch: ${{ github.head_ref }}
+          tagging_message: v${{ env.CORE_VERSION }}


### PR DESCRIPTION
Git tags are now being used to tag Docker releases... so we need to be sure to tag any new releases.

<img width="1619" alt="Screen Shot 2021-02-10 at 7 15 40 PM" src="https://user-images.githubusercontent.com/303226/107599123-5e0bc300-6bd4-11eb-9e56-157bec70c5bc.png">
