### PR TITLE
Remove references to SCHEDULER env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,6 @@ PORT=3000
 WEB_URL=http://localhost:3000
 
 WEB_SERVER=true
-SCHEDULER=true
 WORKERS=1
 SERVER_TOKEN=my-super-cool-server-token
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,5 @@ jobs:
           PORT: 3000
           WEB_URL: http://localhost:3000
           WEB_SERVER: true
-          SCHEDULER: true
           WORKERS: 1
           GROUPAROO_TELEMETRY_ENABLED: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV PORT=3000
 ENV WEB_URL=http://localhost:$PORT
 ENV WEB_SERVER=true
 ENV SERVER_TOKEN="default-server-token"
-ENV SCHEDULER=true
 ENV WORKERS=1
 ENV REDIS_URL="redis://localhost:6379/0"
 ENV DATABASE_URL="postgresql://localhost:5432/grouparoo_development"

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web:    cd node_modules/@grouparoo/core && WEB_SERVER=true  SCHEDULER=true  WORKERS=1  ./api/bin/start
-worker: cd node_modules/@grouparoo/core && WEB_SERVER=false SCHEDULER=true  WORKERS=10 ./api/bin/start
+web:    cd node_modules/@grouparoo/core && WEB_SERVER=true  WORKERS=1  ./api/bin/start
+worker: cd node_modules/@grouparoo/core && WEB_SERVER=false WORKERS=10 ./api/bin/start
 
 # Note: Normally, `web` would have no workers or scheduler, but we want to be able to run the app on a simple heroku deploy

--- a/docker-compose.published.yml
+++ b/docker-compose.published.yml
@@ -25,7 +25,6 @@ services:
       REDIS_URL: redis://redis:6379/0
       DATABASE_URL: postgresql://postgres:password@db:5432/grouparoo_docker
       WEB_SERVER: "true"
-      SCHEDULER: "false"
       WORKERS: 0
       SERVER_TOKEN: "default-server-token"
     depends_on:
@@ -42,7 +41,6 @@ services:
       REDIS_URL: redis://redis:6379/0
       DATABASE_URL: postgresql://postgres:password@db:5432/grouparoo_docker
       WEB_SERVER: "false"
-      SCHEDULER: "true"
       WORKERS: 10
       SERVER_TOKEN: "default-server-token"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       REDIS_URL: redis://redis:6379/0
       DATABASE_URL: postgresql://postgres:password@db:5432/grouparoo_docker
       WEB_SERVER: "true"
-      SCHEDULER: "false"
       WORKERS: 0
       SERVER_TOKEN: "default-server-token"
     depends_on:
@@ -42,7 +41,6 @@ services:
       REDIS_URL: redis://redis:6379/0
       DATABASE_URL: postgresql://postgres:password@db:5432/grouparoo_docker
       WEB_SERVER: "false"
-      SCHEDULER: "true"
       WORKERS: 10
       SERVER_TOKEN: "default-server-token"
     depends_on:

--- a/kube/grouparoo-web.yml
+++ b/kube/grouparoo-web.yml
@@ -23,8 +23,6 @@ spec:
               value: "true"
             - name: WORKERS
               value: "0"
-            - name: SCHEDULER
-              value: "false"
             - name: REDIS_URL
               value: "redis://grouparoo-redis.xxx.ng.0001.use1.cache.amazonaws.com:6379/0"
             - name: DATABASE_URL

--- a/kube/grouparoo-worker.yml
+++ b/kube/grouparoo-worker.yml
@@ -23,8 +23,6 @@ spec:
               value: "false"
             - name: WORKERS
               value: "10"
-            - name: SCHEDULER
-              value: "true"
             - name: REDIS_URL
               value: "redis://grouparoo-redis.xxx.ng.0001.use1.cache.amazonaws.com:6379/0"
             - name: DATABASE_URL


### PR DESCRIPTION
**Relies on grouparoo/grouparoo#1314**

References to `SCHEDULER` were removed from core.

---

⚠️ Note that this could cause an issue for anyone who deploys between merging this and releasing the next core version (the one that will have this adjustment).

